### PR TITLE
UX: Text & width adjustments

### DIFF
--- a/app/services/discourse_rewind/action/top_words.rb
+++ b/app/services/discourse_rewind/action/top_words.rb
@@ -5,11 +5,11 @@ module DiscourseRewind
     class TopWords < BaseReport
       FakeData = {
         data: [
-          { word: "what", score: 100 },
-          { word: "have", score: 90 },
+          { word: "seven", score: 100 },
+          { word: "longest", score: 90 },
           { word: "you", score: 80 },
           { word: "overachieved", score: 70 },
-          { word: "this", score: 60 },
+          { word: "assume", score: 60 },
           { word: "week", score: 50 },
         ],
         identifier: "top-words",

--- a/assets/javascripts/discourse/components/reports/top-words/word-card.gjs
+++ b/assets/javascripts/discourse/components/reports/top-words/word-card.gjs
@@ -47,7 +47,7 @@ export default class WordCard extends Component {
   }
 
   get longWord() {
-    return this.args.word.length >= 7;
+    return this.args.word.length >= 5;
   }
 
   get cardStyle() {

--- a/assets/stylesheets/common/best-posts.scss
+++ b/assets/stylesheets/common/best-posts.scss
@@ -88,6 +88,16 @@
     font-weight: normal;
     font-size: var(--font-down-1);
   }
+  .best-posts__post img {
+    max-width: 100%;
+    height: auto;
+  }
+  .best-posts__post code,
+  .best-posts__post pre {
+    font-family: var(--pixel-text);
+    font-weight: normal;
+    font-size: var(--font-down-1);
+  }
   .best-posts__metadata a {
     font-family: var(--pixel-text);
     text-transform: uppercase;


### PR DESCRIPTION
This PR makes adjustments to:

- max image widths in the best posts section
- code,pre font in the best posts section
- sets a shorter word length check to make font smaller in the top words card section

**Before**
![CleanShot 2025-01-22 at 08 38 46@2x](https://github.com/user-attachments/assets/cc5f553f-0347-41ac-84c2-7ffcd1797b93)

![CleanShot 2025-01-22 at 08 39 01@2x](https://github.com/user-attachments/assets/30e8ba20-8242-40b6-902d-b72479758326)

![CleanShot 2025-01-22 at 08 39 12@2x](https://github.com/user-attachments/assets/7d07aff1-956d-43de-b918-ba0959bde513)



**After**
![CleanShot 2025-01-22 at 08 37 34@2x](https://github.com/user-attachments/assets/5caa9fca-639e-4b7f-b171-3a73842d6727)

![CleanShot 2025-01-22 at 08 37 50@2x](https://github.com/user-attachments/assets/69727956-6838-4103-b3e3-180f230cbf1b)

![CleanShot 2025-01-22 at 08 37 59@2x](https://github.com/user-attachments/assets/81b754ed-2c1b-4919-9f73-6277ef51ad25)

